### PR TITLE
rebase: align Responses API store option with upstream ZDR semantics

### DIFF
--- a/lib/req_llm/providers/openai.ex
+++ b/lib/req_llm/providers/openai.ex
@@ -177,6 +177,12 @@ defmodule ReqLLM.Providers.OpenAI do
       type: :string,
       doc: "Previous response ID for Responses API tool resume flow"
     ],
+    store: [
+      type: :boolean,
+      doc:
+        "Whether to store responses for multi-turn chaining via previous_response_id. " <>
+          "Set to false for Zero Data Retention (ZDR) organizations."
+    ],
     openai_stream_transport: [
       type: {:in, [:sse, :websocket]},
       default: :sse,

--- a/lib/req_llm/providers/openai/responses_api.ex
+++ b/lib/req_llm/providers/openai/responses_api.ex
@@ -501,10 +501,13 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
   def build_request_body(context, model_name, opts, request) do
     opts_map = if is_map(opts), do: opts, else: Map.new(opts)
     provider_opts = opts_map[:provider_options] || []
+    store = Keyword.get(provider_opts, :store, true)
 
     previous_response_id =
-      provider_opts[:previous_response_id] ||
-        extract_previous_response_id_from_context(context)
+      if store != false do
+        provider_opts[:previous_response_id] ||
+          extract_previous_response_id_from_context(context)
+      end
 
     # Build input items and collect system texts in a single pass.
     # When previous_response_id is available, tool calls/results are handled server-side.
@@ -674,7 +677,6 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
     service_tier = opts_map[:service_tier] || provider_opts[:service_tier]
 
     text_format = encode_text_format(provider_opts[:response_format], provider_opts[:verbosity])
-    store = provider_opts[:store]
 
     final_input =
       if previous_response_id == nil and reasoning_items != [] do
@@ -695,13 +697,19 @@ defmodule ReqLLM.Providers.OpenAI.ResponsesAPI do
       |> maybe_put_string("tool_choice", tool_choice)
       |> maybe_put_string("parallel_tool_calls", opts_map[:parallel_tool_calls])
       |> maybe_put_string("service_tier", service_tier)
-      |> maybe_put_string("store", store)
       |> maybe_put_string("text", text_format)
 
-    if previous_response_id do
-      body
-      |> Map.put("previous_response_id", previous_response_id)
-      |> Map.put("store", true)
+    body =
+      if previous_response_id do
+        body
+        |> Map.put("previous_response_id", previous_response_id)
+        |> Map.put("store", true)
+      else
+        body
+      end
+
+    if store == false do
+      Map.put(body, "store", false)
     else
       body
     end

--- a/test/provider/openai/responses_api_unit_test.exs
+++ b/test/provider/openai/responses_api_unit_test.exs
@@ -1282,6 +1282,66 @@ defmodule Provider.OpenAI.ResponsesAPIUnitTest do
              end)
     end
 
+    test "store: false suppresses previous_response_id and sets store to false" do
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
+        metadata: %{response_id: "resp_prev_123"}
+      }
+
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
+      request = build_request(context: context, provider_options: [store: false])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+    end
+
+    test "store: true (default) preserves previous_response_id behavior" do
+      assistant_msg = %ReqLLM.Message{
+        role: :assistant,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Previous answer"}],
+        metadata: %{response_id: "resp_prev_456"}
+      }
+
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Follow up"}]
+      }
+
+      context = %ReqLLM.Context{messages: [assistant_msg, user_msg]}
+      request = build_request(context: context)
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      assert body["previous_response_id"] == "resp_prev_456"
+      assert body["store"] == true
+    end
+
+    test "store: false without prior response_id omits both fields" do
+      user_msg = %ReqLLM.Message{
+        role: :user,
+        content: [%ReqLLM.Message.ContentPart{type: :text, text: "Hello"}]
+      }
+
+      context = %ReqLLM.Context{messages: [user_msg]}
+      request = build_request(context: context, provider_options: [store: false])
+
+      encoded = ResponsesAPI.encode_body(request)
+      body = Jason.decode!(encoded.body)
+
+      refute Map.has_key?(body, "previous_response_id")
+      assert body["store"] == false
+    end
+
     test "skips non-OpenAI reasoning details with warning" do
       import ExUnit.CaptureLog
 


### PR DESCRIPTION
## Summary
- add OpenAI provider schema support for `provider_options[:store]` so `store: false` is a valid, validated option
- align Responses API request building with upstream behavior: when `store: false`, skip `previous_response_id` chaining and send `\"store\": false`; otherwise preserve current chaining behavior
- add unit coverage for `store: false` and default `store: true` chaining behavior in Responses API encoding

## Validation
- `mix test test/provider/openai/responses_api_unit_test.exs`
- `mix test test/providers/openai_codex_test.exs`
- `mix test test/frontman_server/providers/codex_test.exs test/frontman_server/providers/resolved_key_test.exs` (from `~/dev/frontman/apps/frontman_server`)

Closes #8.